### PR TITLE
fix redis deprecation warning

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,13 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists(:schedules) }
+      Sidekiq.redis do |r|
+        if r.respond_to?(:exists?)
+          r.exists?(:schedules)
+        else
+          !!r.exists(:schedules)
+        end
+      end
     end
 
     # Returns all the schedule changes for a given time range.


### PR DESCRIPTION
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.